### PR TITLE
Remove tile navigation from FAQ and update docs

### DIFF
--- a/Business-Rules.md
+++ b/Business-Rules.md
@@ -40,7 +40,7 @@ A consolidated set of rules and guidelines for building the new TAP FAQs page. U
 ### 3.1 Color Tokens
 ```css
 --tap-blue       : #0096D6;   /* Primary */
---tap-light-blue : #6FC4E9;   /* Selected tile / hover */
+--tap-light-blue : #6FC4E9;   /* Hover */
 --tap-orange     : #DB7D07;   /* Highlights / warnings */
 --tap-grey-bg    : #F2F6F9;   /* Light backgrounds */
 --tap-white      : #FFFFFF;
@@ -59,7 +59,7 @@ A consolidated set of rules and guidelines for building the new TAP FAQs page. U
 | Base unit     | 8 px grid                                         |
 | Desktop grid  | 12 columns, 80 px gutter                          |
 | Mobile grid   | 4 columns, 16 px gutter                           |
-| Corner radius | 8 px (tiles / accordions), 15 px (search bar)     |
+| Corner radius | 8 px (accordions), 15 px (search bar)     |
 | Shadow        | 0 2 4 0 rgba(0,0,0,0.08) on hover / active panels |
 
 ### 3.4 Components
@@ -68,12 +68,6 @@ A consolidated set of rules and guidelines for building the new TAP FAQs page. U
 - Height 60 px, full-width.
 - BG `var(--tap-grey-bg)` with 1 px border `#D0D0D0`.
 - Placeholder style 18 px / `var(--tap-text-dark)`.
-
-**Category Tile**
-
-- Size 170 × 130 px desktop, 160 × 140 px mobile.
-- BG `var(--tap-blue)`; selected → `var(--tap-light-blue)` + 2 px outline `var(--tap-blue)`.
-- Icon circle 60 px, white abbreviation label 20 px bold.
 
 **Accordion Header**
 
@@ -95,21 +89,19 @@ A consolidated set of rules and guidelines for building the new TAP FAQs page. U
 ```
 
 ### 3.5 Behaviour & States
-- Tiles multi-select: Users can toggle any combination; state drives accordion open/close.
 - **Search:**
   - Case-insensitive substring match across questions and answers.
   - On input: expand categories with hits, collapse others, highlight matches.
-  - Empty query → restore pre-search selection.
+  - Empty query → restore pre-search open state.
   - No-results state: Centered illustration + “No FAQs matched your search” in `var(--tap-orange)`.
 
 ### 3.6 Accessibility
 - All interactive elements are real `<button>` or `<a>` with `aria-expanded` where applicable.
-- Keyboard ↔ : Tab focuses tile, Enter toggles; arrow keys navigate tiles in row / grid.
+- Keyboard: Tab focuses accordion headers, Enter toggles sections.
 - Colour contrast ≥ 4.5:1 for all text.
 - Focus ring 2 px outline `var(--tap-orange)` (WCAG AA visible).
 
 ### 3.7 Motion
-- Tiles hover: 0.15 s background fade.
 - Accordion: 0.2 s ease-in-out height animation; chevron syncs.
 
 ---

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This repository stores the static markup used to build the TAP FAQ pages. No
 runtime generation or CSV processing is performed here—everything is written as
-HTML snippets that can be dropped directly into the production site.
+HTML snippets that can be dropped directly into the production site. The FAQ
+interface uses a simple search bar and accordion sections; earlier tile-based
+navigation has been removed.
 
 See [ARCHITECTUREOVERVIEW.md](ARCHITECTUREOVERVIEW.md) for details on the
 overall HTML structure and guidance on integrating the snippets.

--- a/index.html
+++ b/index.html
@@ -49,55 +49,6 @@
       pointer-events: none;
     }
 
-    /* Tiles */
-    .tile-container {
-      display: flex;
-      gap: 10px;
-      margin-bottom: 30px;
-      overflow-x: auto;
-    }
-
-    .faq-tile {
-      flex: 1;
-      min-width: 160px;
-      max-width: 180px;
-      background-color: #6fc4e9;
-      color: #000;
-      text-align: center;
-      border-radius: 8px;
-      padding: 12px 10px;
-      cursor: pointer;
-      transition: background-color 0.2s ease;
-      display: flex;
-      flex-direction: column;
-      justify-content: flex-start;
-      align-items: center;
-    }
-
-    .faq-tile.selected {
-      background-color: #0096d6;
-      color: #fff;
-    }
-
-    .faq-tile .icon {
-      width: 46px;
-      height: 46px;
-      margin-bottom: 8px;
-      border-radius: 50%;
-      background-color: #005b8c;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      color: #fff;
-      font-weight: bold;
-      font-size: 16px;
-    }
-
-    .faq-tile .label {
-      font-size: 14px;
-      line-height: 1.2;
-    }
-
     /* Accordion sections */
     .faq-section {
       border: 1px solid #dcdcdc;
@@ -211,15 +162,6 @@
       font-size: 14px;
     }
 
-    /* Responsive: stack tiles on small screens */
-    @media (max-width: 640px) {
-      .tile-container {
-        flex-wrap: wrap;
-      }
-      .faq-tile {
-        flex: 0 0 calc(50% - 5px);
-      }
-    }
   </style>
   </head>
   <body>
@@ -243,33 +185,6 @@
     <div class="search-container">
       <input type="text" id="searchInput" placeholder="Search FAQs">
       <span class="search-icon">🔍</span>
-    </div>
-    <!-- Category Tiles -->
-    <div class="tile-container">
-      <div class="faq-tile selected" data-index="0">
-        <div class="icon">GI</div>
-        <div class="label">General Info &amp; Getting a TAP Card</div>
-      </div>
-      <div class="faq-tile selected" data-index="1">
-        <div class="icon">UT</div>
-        <div class="label">Using TAP on Transit &amp; Other Services</div>
-      </div>
-      <div class="faq-tile selected" data-index="2">
-        <div class="icon">MC</div>
-        <div class="label">Managing Your TAP Card &amp; Account</div>
-      </div>
-      <div class="faq-tile selected" data-index="3">
-        <div class="icon">AF</div>
-        <div class="label">Adding Fare, Fare Products &amp; Payment Options</div>
-      </div>
-      <div class="faq-tile" data-index="4">
-        <div class="icon">MA</div>
-        <div class="label">TAP Mobile App &amp; Digital TAP Cards</div>
-      </div>
-      <div class="faq-tile" data-index="5">
-        <div class="icon">DS</div>
-        <div class="label">Discounts &amp; Special Programs</div>
-      </div>
     </div>
     <!-- Accordion Sections for each Category -->
     <div class="faq-section open" id="section0">
@@ -1086,31 +1001,25 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const searchInput = document.getElementById('searchInput');
-      const tiles = document.querySelectorAll('.faq-tile');
       const sections = document.querySelectorAll('.faq-section');
-      // Keep track of selection state before search
-      let preSearchSelected = [];
+      // Keep track of open sections before search
+      let preSearchOpen = [];
 
-      // Toggle sections when tiles are clicked
-      tiles.forEach((tile) => {
-        const index = parseInt(tile.getAttribute('data-index'));
-        const section = sections[index];
-        tile.addEventListener('click', () => {
-          // In search mode, ignore tile clicks
-          if (searchInput.value.trim() !== '') return;
-          tile.classList.toggle('selected');
-          section.classList.toggle('open');
+      // Store original question text for highlighting
+      sections.forEach((section) => {
+        section.querySelectorAll('li').forEach((li) => {
+          const questionSpan = li.querySelector('.question');
+          li.setAttribute('data-original', questionSpan.textContent);
         });
       });
 
       // Toggle section when header is clicked
-      sections.forEach((section, idx) => {
+      sections.forEach((section) => {
         const header = section.querySelector('.faq-section-header');
         header.addEventListener('click', () => {
           // In search mode, ignore header clicks
           if (searchInput.value.trim() !== '') return;
-          sections[idx].classList.toggle('open');
-          tiles[idx].classList.toggle('selected');
+          section.classList.toggle('open');
         });
         // Toggle individual questions
         section.querySelectorAll('li').forEach((li) => {
@@ -1125,62 +1034,55 @@
       searchInput.addEventListener('input', () => {
         const term = searchInput.value.trim().toLowerCase();
         if (term === '') {
-          // When search cleared, restore original states
-            sections.forEach((section, idx) => {
-              // Hide or show section based on preSearchSelected
-              if (preSearchSelected.includes(idx)) {
-                section.classList.add('open');
-                tiles[idx].classList.add('selected');
-              } else {
-                section.classList.remove('open');
-                tiles[idx].classList.remove('selected');
-              }
-              // Restore all questions
-              section.querySelectorAll('li').forEach((li) => {
-                li.style.display = '';
-                li.classList.remove('open');
-                const questionSpan = li.querySelector('.question');
-                questionSpan.innerHTML = li.getAttribute('data-original');
-              });
+          // When search cleared, restore original open states
+          sections.forEach((section, idx) => {
+            if (preSearchOpen.includes(idx)) {
+              section.classList.add('open');
+            } else {
+              section.classList.remove('open');
+            }
+            // Restore all questions
+            section.querySelectorAll('li').forEach((li) => {
+              li.style.display = '';
+              li.classList.remove('open');
+              const questionSpan = li.querySelector('.question');
+              questionSpan.innerHTML = li.getAttribute('data-original');
             });
-          preSearchSelected = [];
+          });
+          preSearchOpen = [];
           return;
         }
-        // Store current selected state only once at the beginning of search
-        if (preSearchSelected.length === 0) {
-          tiles.forEach((tile, idx) => {
-            if (tile.classList.contains('selected')) preSearchSelected.push(idx);
+        // Store current open state only once at the beginning of search
+        if (preSearchOpen.length === 0) {
+          sections.forEach((section, idx) => {
+            if (section.classList.contains('open')) preSearchOpen.push(idx);
           });
         }
         // For each category, check if any question matches
-          sections.forEach((section, idx) => {
-            let hasMatch = false;
-            section.querySelectorAll('li').forEach((li) => {
-              const originalText = li.getAttribute('data-original');
-              const answerText = li.querySelector('.answer').textContent.toLowerCase();
-              const lowerOriginal = originalText.toLowerCase();
-              if (lowerOriginal.includes(term) || answerText.includes(term)) {
-                hasMatch = true;
-                li.style.display = '';
-                li.classList.add('open');
-                const regex = new RegExp(term, 'gi');
-                const questionSpan = li.querySelector('.question');
-                questionSpan.innerHTML = originalText.replace(regex, (match) => `<span class="highlight">${match}</span>`);
-              } else {
-                li.style.display = 'none';
-                li.classList.remove('open');
-                const questionSpan = li.querySelector('.question');
-                questionSpan.innerHTML = originalText;
-              }
-            });
-            if (hasMatch) {
-              // Show this category and tile as selected
-              section.classList.add('open');
-              tiles[idx].classList.add('selected');
+        sections.forEach((section, idx) => {
+          let hasMatch = false;
+          section.querySelectorAll('li').forEach((li) => {
+            const originalText = li.getAttribute('data-original');
+            const answerText = li.querySelector('.answer').textContent.toLowerCase();
+            const lowerOriginal = originalText.toLowerCase();
+            if (lowerOriginal.includes(term) || answerText.includes(term)) {
+              hasMatch = true;
+              li.style.display = '';
+              li.classList.add('open');
+              const regex = new RegExp(term, 'gi');
+              const questionSpan = li.querySelector('.question');
+              questionSpan.innerHTML = originalText.replace(regex, (match) => `<span class="highlight">${match}</span>`);
+            } else {
+              li.style.display = 'none';
+              li.classList.remove('open');
+              const questionSpan = li.querySelector('.question');
+              questionSpan.innerHTML = originalText;
+            }
+          });
+          if (hasMatch) {
+            section.classList.add('open');
           } else {
-            // Hide category (collapse) and remove tile selection
             section.classList.remove('open');
-            tiles[idx].classList.remove('selected');
           }
         });
       });


### PR DESCRIPTION
## Summary
- streamline FAQ layout by removing category tiles and relying on search and accordions
- simplify JavaScript to restore section state without tile dependencies
- update project documentation to reflect accordion-only interface

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894fc5af9b4832b9c3971ba97c02102