### PR TITLE
Add animated chevrons to FAQ accordions

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,13 +73,16 @@
     }
 
     .faq-section-content {
-      display: none;
+      max-height: 0;
+      overflow: hidden;
       background-color: #ffffff;
-      padding: 12px 16px;
+      padding: 0 16px;
+      transition: max-height 0.3s ease, padding 0.3s ease;
     }
 
     .faq-section.open .faq-section-content {
-      display: block;
+      max-height: 5000px;
+      padding: 12px 16px;
     }
 
     .faq-section-content ul {
@@ -98,13 +101,17 @@
     }
 
     .faq-section-content li .answer {
-      display: none;
-      margin-top: 6px;
-      padding: .5em 0 1em 0;
+      max-height: 0;
+      overflow: hidden;
+      margin-top: 0;
+      padding: 0;
+      transition: max-height 0.3s ease, padding 0.3s ease;
     }
 
     .faq-section-content li.open .answer {
-      display: block;
+      max-height: 500px;
+      margin-top: 6px;
+      padding: .5em 0 1em 0;
     }
 
     .faq-section-content ul {
@@ -127,6 +134,30 @@
 
     .question {
         color: #ea0b8b;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        width: 100%;
+    }
+
+    .question::after {
+      content: '\25B6';
+      color: #0096d6;
+      transition: transform 0.3s ease;
+    }
+
+    li.open .question::after {
+      transform: rotate(90deg);
+    }
+
+    .faq-section-header::after {
+      content: '\25B6';
+      color: #0096d6;
+      transition: transform 0.3s ease;
+    }
+
+    .faq-section.open .faq-section-header::after {
+      transform: rotate(90deg);
     }
 
     /* Header */


### PR DESCRIPTION
## Summary
- Add rotating chevron indicators to FAQ section headers and questions
- Animate accordion open/close with CSS transitions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894ff282850832bb696c72cd1da9094