### PR TITLE
feat: add clearable search box

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,27 +26,50 @@
 
     /* Search bar */
     .search-container {
-      position: relative;
+      display: flex;
+      align-items: center;
+      background: #fff;
+      border: 1px solid #ccc;
+      border-radius: 9999px;
+      padding: 4px 12px;
       margin-bottom: 25px;
     }
 
     .search-container input {
-      width: 100%;
-      padding: 14px 45px 14px 14px;
-      border: 1px solid #ccc;
-      border-radius: 15px;
-      font-size: 16px;
+      flex: 1;
+      border: none;
       outline: none;
+      font-size: 16px;
+      padding: 8px;
+      background: transparent;
+    }
+
+    .search-container button {
+      background: none;
+      border: none;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      font-size: 18px;
+      padding: 0 8px;
     }
 
     .search-container .search-icon {
-      position: absolute;
-      right: 16px;
-      top: 50%;
-      transform: translateY(-50%);
-      font-size: 18px;
       color: #0096d6;
-      pointer-events: none;
+      opacity: 0.8;
+    }
+
+    .search-container .search-icon:hover {
+      opacity: 1;
+    }
+
+    .search-container .clear-icon {
+      color: #66b2ff;
+      display: none;
+    }
+
+    .search-container .clear-icon:hover {
+      color: #0096d6;
     }
 
     /* Category list */
@@ -261,7 +284,8 @@
     <!-- Search Bar -->
     <div class="search-container">
       <input type="text" id="searchInput" placeholder="Search FAQs">
-      <span class="search-icon">🔍</span>
+      <button type="button" id="clearSearch" class="clear-icon" aria-label="Clear search">✕</button>
+      <button type="button" id="searchButton" class="search-icon" aria-label="Search">🔍</button>
     </div>
     <div class="list-container">
       <ul class="styled-list">
@@ -1141,65 +1165,89 @@
           });
         }
 
-      // Search functionality
+      const clearBtn = document.getElementById('clearSearch');
+      const searchBtn = document.getElementById('searchButton');
+
+      clearBtn.addEventListener('click', () => {
+        searchInput.value = '';
+        toggleClear();
+        handleSearch();
+        searchInput.focus();
+      });
+
+      searchBtn.addEventListener('click', handleSearch);
+
       searchInput.addEventListener('input', () => {
+        toggleClear();
+        handleSearch();
+      });
+
+      function toggleClear() {
+        if (searchInput.value.trim() !== '') {
+          clearBtn.style.display = 'flex';
+        } else {
+          clearBtn.style.display = 'none';
+        }
+      }
+
+      function handleSearch() {
         const term = searchInput.value.trim().toLowerCase();
         if (term === '') {
-          // When search cleared, restore original open states
-            sections.forEach((section, idx) => {
-              if (preSearchOpen.includes(idx)) {
-                section.classList.add('open');
-              } else {
-                section.classList.remove('open');
-              }
-              // Restore all questions
-              section.querySelectorAll('li').forEach((li) => {
-                li.style.display = '';
-                li.classList.remove('open');
-                const questionSpan = li.querySelector('.question');
-                questionSpan.innerHTML = li.getAttribute('data-original');
-              });
+          sections.forEach((section, idx) => {
+            if (preSearchOpen.includes(idx)) {
+              section.classList.add('open');
+            } else {
+              section.classList.remove('open');
+            }
+            section.querySelectorAll('li').forEach((li) => {
+              li.style.display = '';
+              li.classList.remove('open');
+              const questionSpan = li.querySelector('.question');
+              questionSpan.innerHTML = li.getAttribute('data-original');
             });
-            preSearchOpen = [];
-            updateCategoryStates();
-            return;
-          }
-        // Store current open state only once at the beginning of search
+          });
+          preSearchOpen = [];
+          updateCategoryStates();
+          return;
+        }
+
         if (preSearchOpen.length === 0) {
           sections.forEach((section, idx) => {
             if (section.classList.contains('open')) preSearchOpen.push(idx);
           });
         }
-        // For each category, check if any question matches
-          sections.forEach((section, idx) => {
-            let hasMatch = false;
-            section.querySelectorAll('li').forEach((li) => {
-              const originalText = li.getAttribute('data-original');
-              const answerText = li.querySelector('.answer').textContent.toLowerCase();
-              const lowerOriginal = originalText.toLowerCase();
-              if (lowerOriginal.includes(term) || answerText.includes(term)) {
-                hasMatch = true;
-                li.style.display = '';
-                li.classList.add('open');
-                const regex = new RegExp(term, 'gi');
-                const questionSpan = li.querySelector('.question');
-                questionSpan.innerHTML = originalText.replace(regex, (match) => `<span class="highlight">${match}</span>`);
-              } else {
-                li.style.display = 'none';
-                li.classList.remove('open');
-                const questionSpan = li.querySelector('.question');
-                questionSpan.innerHTML = originalText;
-              }
-            });
-            if (hasMatch) {
-              section.classList.add('open');
+
+        sections.forEach((section, idx) => {
+          let hasMatch = false;
+          section.querySelectorAll('li').forEach((li) => {
+            const originalText = li.getAttribute('data-original');
+            const answerText = li.querySelector('.answer').textContent.toLowerCase();
+            const lowerOriginal = originalText.toLowerCase();
+            if (lowerOriginal.includes(term) || answerText.includes(term)) {
+              hasMatch = true;
+              li.style.display = '';
+              li.classList.add('open');
+              const regex = new RegExp(term, 'gi');
+              const questionSpan = li.querySelector('.question');
+              questionSpan.innerHTML = originalText.replace(regex, (match) => `<span class="highlight">${match}</span>`);
             } else {
-              section.classList.remove('open');
+              li.style.display = 'none';
+              li.classList.remove('open');
+              const questionSpan = li.querySelector('.question');
+              questionSpan.innerHTML = originalText;
             }
           });
-          updateCategoryStates();
+          if (hasMatch) {
+            section.classList.add('open');
+          } else {
+            section.classList.remove('open');
+          }
         });
         updateCategoryStates();
+      }
+
+      updateCategoryStates();
+      toggleClear();
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- modernize search bar styling with pill-shaped input and inline icons
- add conditional clear button that resets search text
- enable search icon click and hover effects while preserving existing logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689512394518832bb2c9019f4b724ac2