### PR TITLE
Highlight search matches in answers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1242,11 +1242,13 @@
         // Keep track of open sections before search
         let preSearchOpen = [];
 
-      // Store original question text for highlighting
+      // Store original question and answer text for highlighting
       forEach(sections, function(section) {
         forEach(section.querySelectorAll('.faq-section-content > ul > li'), function(li) {
           const questionSpan = li.querySelector('.question');
-          li.setAttribute('data-original', questionSpan.textContent);
+          const answerDiv = li.querySelector('.answer');
+          li.setAttribute('data-original-question', questionSpan.textContent);
+          li.setAttribute('data-original-answer', answerDiv.innerHTML);
         });
       });
 
@@ -1324,7 +1326,9 @@
               li.style.display = '';
               li.classList.remove('open');
               const questionSpan = li.querySelector('.question');
-              questionSpan.innerHTML = li.getAttribute('data-original');
+              const answerDiv = li.querySelector('.answer');
+              questionSpan.innerHTML = li.getAttribute('data-original-question');
+              answerDiv.innerHTML = li.getAttribute('data-original-answer');
             });
           });
           preSearchOpen = [];
@@ -1341,21 +1345,24 @@
         forEach(sections, function(section, idx) {
           let hasMatch = false;
           forEach(section.querySelectorAll('.faq-section-content > ul > li'), function(li) {
-            const originalText = li.getAttribute('data-original');
+            const originalQuestion = li.getAttribute('data-original-question');
+            const originalAnswer = li.getAttribute('data-original-answer');
             const answerText = li.querySelector('.answer').textContent.toLowerCase();
-            const lowerOriginal = originalText.toLowerCase();
-            if (lowerOriginal.includes(term) || answerText.includes(term)) {
+            const lowerQuestion = originalQuestion.toLowerCase();
+            const questionSpan = li.querySelector('.question');
+            const answerDiv = li.querySelector('.answer');
+            if (lowerQuestion.includes(term) || answerText.includes(term)) {
               hasMatch = true;
               li.style.display = '';
               li.classList.add('open');
               const regex = new RegExp(term, 'gi');
-              const questionSpan = li.querySelector('.question');
-              questionSpan.innerHTML = originalText.replace(regex, function(match) { return '<span class="highlight">' + match + '</span>'; });
+              questionSpan.innerHTML = originalQuestion.replace(regex, function(match) { return '<span class="highlight">' + match + '</span>'; });
+              answerDiv.innerHTML = originalAnswer.replace(regex, function(match) { return '<span class="highlight">' + match + '</span>'; });
             } else {
               li.style.display = 'none';
               li.classList.remove('open');
-              const questionSpan = li.querySelector('.question');
-              questionSpan.innerHTML = originalText;
+              questionSpan.innerHTML = originalQuestion;
+              answerDiv.innerHTML = originalAnswer;
             }
           });
           if (hasMatch) {


### PR DESCRIPTION
## Summary
- store original question and answer HTML to enable restoring search state
- search now highlights matches in answers as well as questions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68951cd74568832b9be16c13f8734769